### PR TITLE
Add sparkui port spec to docker yaml files

### DIFF
--- a/hitchhikers_guide/docker-compose-arm64.yaml
+++ b/hitchhikers_guide/docker-compose-arm64.yaml
@@ -12,4 +12,5 @@ services:
       - ${PWD}:/opt/spark/work-dir/hitchhikers_guide
     ports:
       - 8888-8889:8888-8889
+      - 4040:4040
     restart: always

--- a/hitchhikers_guide/docker-compose.yaml
+++ b/hitchhikers_guide/docker-compose.yaml
@@ -12,4 +12,5 @@ services:
       - ${PWD}:/opt/spark/work-dir/hitchhikers_guide
     ports:
       - 8888-8889:8888-8889
+      - 4040:4040
     restart: always


### PR DESCRIPTION
## Description

Allows us to be able to use the Spark UI in a local browser
On my WSL machine I have to set the following conf:

spark.conf.set("yarn.web-proxy.address", "localhost")

Not sure if this is universal (I think it is) but this allowed me to pull up the spark UI in the browser.

## How was this patch tested?

Works on my machine lol

## Does this PR introduce _any_ user-facing changes?

Enables the port from the container for Spark UI access.