### PR TITLE
13 add triggered streaming write to dl streaming 101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ hitchhikers_guide/datasets/ecomm_behavior_data/2019-Oct.csv
 hitchhikers_guide/datasets/ecomm_behavior_data/2019-Nov.csv
 hitchhikers_guide/datasets/ecomm_behavior_data/parquet/lg
 hitchhikers_guide/datasets/ecomm_behavior_data/delta/ecomm
+
+# ignore the application directory since it is for application checkpoints
+hitchhikers_guide/applications/*

--- a/hitchhikers_guide/README.md
+++ b/hitchhikers_guide/README.md
@@ -12,3 +12,15 @@ If you want to dive into using Delta Lake, head on over to [notebooks/first-step
 
 # When Things Go Bump in the Night
 The collection of notebooks under `when-things-go-bump-in-the-night` are targeted towards fixing issues that pop-up at the worst times. This is the 3am style issues. Remember `Don't Panic`, take a deep breath, and remember the guide is here to help.
+
+> random note: 
+
+Get the core counts for your local machine. (if mac)
+```
+sysctl -a | grep machdep.cpu
+```
+
+linux
+```
+cat /proc/cpuinfo
+```

--- a/hitchhikers_guide/applications/README.md
+++ b/hitchhikers_guide/applications/README.md
@@ -1,0 +1,20 @@
+# What is this directory for (applications)?
+This directory is a common place to store you application state when using "The Guide". Delta Streaming applications require "state" so when the worst happens, you can pick up where you left off (regardless if the cluster you were running on survived) - just use your "thumb" and hitch a ride on a new cluster.
+
+## Patterns
+The way we develop streaming applications isn't very different from traditional software applications.
+
+1. You will have your application committed to some kind of version control system (let's be honest, you are using github). That at least has a sha checksum. (you can even use `tags` to denote releases - with that said use `git releases` to do your releases!)
+2. Your application will not be `final` on day one. The first release *is day one*. This means you will be making adjustments to the way the application works throughout the lifecycle of the application. So each release needs a way to be 'referenced' so you can 'deploy' a new version, or *'rollback' to the last good version. (hopefully you don't need to rollback, simple unit tests go a long way, plus Delta Lake makes it easy to trust yourself - schema-on-write is a good safe-guard especially when coupled with `commit-based schema enforcement`.
+3. You may want to keep the `prior` version of your application `on-call` in the case something bad happens. This means, you'll need to `keep` a copy of the `application state`, so you can `time-travel` in your application just like we can `time-travel` on our Delta Lake tables.
+
+With that said. If you have application code, and also want to store `checkpoints` for the application state, you can keep them safely nestled in the same `cloud-based directory`. For example, `s3://[dev|prod].com.your.company/` could be a bucket, and the contents are the applications and version history.
+
+```
+applications
+└── stream_aggs
+    ├── v1.0.0
+    └── v1.0.1
+```
+
+Whatever works with you and your team. This pattern is a suggestion by the author (Scott Haines)

--- a/hitchhikers_guide/docker-compose-arm64.yaml
+++ b/hitchhikers_guide/docker-compose-arm64.yaml
@@ -13,4 +13,12 @@ services:
     ports:
       - 8888-8889:8888-8889
       - 4040:4040
+    deploy:
+      resources:
+        limits:
+          cpus: '8'
+          memory: 32G
+        reservations:
+          cpus: '1'
+          memory: 16G
     restart: always

--- a/hitchhikers_guide/docker-compose.yaml
+++ b/hitchhikers_guide/docker-compose.yaml
@@ -13,4 +13,12 @@ services:
     ports:
       - 8888-8889:8888-8889
       - 4040:4040
+    deploy:
+      resources:
+        limits:
+          cpus: '8'
+          memory: 32G
+        reservations:
+          cpus: '1'
+          memory: 16G
     restart: always

--- a/hitchhikers_guide/notebooks/first-steps/dl-streaming-101.ipynb
+++ b/hitchhikers_guide/notebooks/first-steps/dl-streaming-101.ipynb
@@ -11,6 +11,9 @@
    "source": [
     "# run first. then have fun.\n",
     "from pyspark.sql.functions import col, current_timestamp, to_date, datediff\n",
+    "# stats and agg functions\n",
+    "from pyspark.sql.functions import count, session_window, window, sum, min, max, percentile_approx\n",
+    "\n",
     "from delta.tables import DeltaTable\n",
     "\n",
     "# keep the default compression codec as zstd\n",
@@ -126,28 +129,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5c3eb912-19c2-4354-8abf-954701bde8eb",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
-      "|now                       |todays_date|createdAt              |lastModified           |age_in_days|stale_days|\n",
-      "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
-      "|2023-06-26 16:10:11.637598|2023-06-26 |2023-06-24 00:13:12.254|2023-06-24 00:33:45.298|2          |2         |\n",
-      "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
-      "\n",
-      "Don't Panic!\n",
-      "The table default.ecomm_by_day is owned by dldg_authors.\n",
-      "We can always contact them via slack @ https://delta-users.slack.com/archives/CG9LR6LN4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Feel Free to Mess with the following cell to get used to the data available to you about the ecomm_by_day table.\n",
     "\n",
@@ -183,25 +170,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "1474d650-5a72-47ea-9214-b327b0a75da8",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+--------+--------------------+------------------+\n",
-      "|numFiles|TableSizeInMegaBytes|      avgMBPerFile|\n",
-      "+--------+--------------------+------------------+\n",
-      "|      72|          806.591728|11.202662888888888|\n",
-      "+--------+--------------------+------------------+\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bytesToMB = 1000000\n",
     "(tbl_dets\n",
@@ -228,28 +202,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "de32047a-73c9-46fc-9858-178cbf1bab06",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "The Table has 42448764 rows.\n",
-      "\n",
-      "(Maybe) Daily Rows of 589566.1666666666\n",
-      "\n",
-      "(Maybe) Average Row Size 0.05262732374562611 in Bytes\n",
-      "\n",
-      "(Maybe) Average Rows per Delta Lake File 589566.1666666666\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# convert the DeltaTable reference to a DataFrame\n",
     "\n",
@@ -286,32 +244,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "id": "fb2ca66b-c1d7-4df1-be63-2685949069e0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#spark.sql(\"drop table default.ecomm_aggs_table\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c78ea8fe-c4ab-48cd-b3e6-65aa4fadf7a3",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "checkpoint_path=../../applications/dl_streaming_aggs/v0.0.1/_checkpoints\n",
-      "root\n",
-      " |-- event_time: timestamp (nullable = true)\n",
-      " |-- event_type: string (nullable = true)\n",
-      " |-- product_id: integer (nullable = true)\n",
-      " |-- category_id: long (nullable = true)\n",
-      " |-- category_code: string (nullable = true)\n",
-      " |-- brand: string (nullable = true)\n",
-      " |-- price: float (nullable = true)\n",
-      " |-- user_id: integer (nullable = true)\n",
-      " |-- user_session: string (nullable = true)\n",
-      " |-- event_date: date (nullable = true)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# read from the `default.ecomm_by_day` table, modify the read options to limit the maxFilesPerTrigger\n",
     "# read up to 4 files, do a simple projection (select colA, colB)\n",
@@ -322,15 +272,15 @@
     "app_version = \"v0.0.1\"\n",
     "checkpoint_dir = \"../../applications\"\n",
     "checkpoint_path = f\"{checkpoint_dir}/{app_name}/{app_version}/_checkpoints\"\n",
-    "print(f\"checkpoint_path={checkpoint_path}\")\n",
+    "#print(f\"checkpoint_path={checkpoint_path}\")\n",
+    "ecomm_aggs_table = 'default.ecomm_aggs_table'\n",
     "\n",
-    "# oh, and only do this Once, so introduce `trigger(once=True)` since we will be `ramping` up to full streaming\n",
-    "\n",
+    "spark.conf.set(\"spark.sql.shuffle.partitions\", \"32\")\n",
     "# create the streaming Delta source object\n",
     "ecomm_by_day_limited = (\n",
     "    spark.readStream\n",
     "    .format(\"delta\")\n",
-    "    .option(\"maxFilesPerTrigger\", 4)\n",
+    "    .option(\"maxFilesPerTrigger\", 1)\n",
     "    .option(\"ignoreChanges\", True)\n",
     "    .table(dl_managed_table)\n",
     ")\n",
@@ -338,13 +288,276 @@
     "# view the schema for the table (since we know everything else about it now too)\n",
     "ecomm_by_day_limited.printSchema()\n",
     "\n",
-    "# next select the columns we care about, even add some - this is a safe place to learn and test things out\n",
+    "# next select the columns we care about (feel free to switch things up here too)\n",
+    "ecomm_aggs = (\n",
+    "    ecomm_by_day_limited\n",
+    "    .withWatermark(\"event_time\", '10 minutes')\n",
+    "    .select(\"event_time\", \"event_type\", \"product_id\", \"user_session\", \"user_id\", \"event_date\")\n",
+    "    .groupBy(window(\"event_time\", \"30 minutes\"), \"user_id\", \"product_id\", \"event_date\")\n",
+    "    .agg(count(\"event_type\").alias('session_events'))\n",
+    ")\n",
     "\n",
-    "# next create the streaming sink \n",
-    "# (.writeStream.format('delta').option....trigger(once=True).toTable('default.otherMangedTableName')\n",
+    "# next create the streaming sink\n",
     "\n",
-    "# oh, and introduce the streamingQuery object (since we'll brush up on metrics and statistics since they\n",
-    "# are also important for Delta Lake streaming..."
+    "streamingQuery = (\n",
+    "    ecomm_aggs.writeStream\n",
+    "    .format(\"delta\")\n",
+    "    .option(\"checkpointLocation\", checkpoint_path)\n",
+    "    .outputMode(\"append\")\n",
+    "    .partitionBy(\"event_date\")\n",
+    "    .option(\"overwriteSchema\", True)\n",
+    "    # triggers allow us to control the frequency in which a job will run. \n",
+    "    # For the java nerds (me included) triggers run like scheduledThreadPools when using `processingTime` \n",
+    "    # and once, will fire once and then the job will complete.\n",
+    "    .trigger(processingTime='30 seconds')\n",
+    "    .toTable(ecomm_aggs_table)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fae0347-0f25-49d3-90f9-9e5ca8977281",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Controlling the StreamingQuery\n",
+    "1. We returned a `streamingQuery` object when we executed the last cell before. The Streaming Query object provides you with a gateway into the realtime metrics and behavior of your Delta-Spark based application performance.\n",
+    "\n",
+    "2. Given the application is `triggering` every `30s` that means twice a minute we'll have more data, as the job slowly chews through the 72 files of the data set, pulling in 600k files per tick.\n",
+    "\n",
+    "Take a look at the metadata provided to you by the `streamingQuery`. Think about how impressive the numbers are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f5c9735-e6e2-4354-99ad-f252b0b6a8d0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "streamingQuery.lastProgress"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b994d389-df47-4a30-b344-831e3da1a9b2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "^^ The prior output from the StreamingQueryListener is an aggregation of the collected runtime metadata, and statistical\n",
+    "behavior captured during the last microBatch. You'll notice that we started on index 16, and endingOffset was 17.\n",
+    "\n",
+    "# Viewing the Delta Lake Information in the Streaming Query Stats\n",
+    "```\n",
+    "'startOffset': {\n",
+    "  'sourceVersion': 1,\n",
+    "  'reservoirId': '027b3701-5c07-46d4-9d96-e5539f81e8bf',\n",
+    "  'reservoirVersion': 33,\n",
+    "  'index': 16,\n",
+    "  'isStartingVersion': True},\n",
+    "'endOffset': {\n",
+    "  'sourceVersion': 1,\n",
+    "  'reservoirId': '027b3701-5c07-46d4-9d96-e5539f81e8bf',\n",
+    "  'reservoirVersion': 33,\n",
+    "  'index': 17,\n",
+    "  'isStartingVersion': True\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "This means we can take a look at the operations in the `/_checkpoints/offsets/17` directory. \n",
+    "\n",
+    "```\n",
+    "v1\n",
+    "{\"batchWatermarkMs\":1570578599000,\"batchTimestampMs\":1687853100013,\"conf\":{\"spark.sql.streaming.stateStore.providerClass\":\"org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider\",\"spark.sql.streaming.join.stateFormatVersion\":\"2\",\"spark.sql.streaming.stateStore.compression.codec\":\"lz4\",\"spark.sql.streaming.stateStore.rocksdb.formatVersion\":\"5\",\"spark.sql.streaming.statefulOperator.useStrictDistribution\":\"true\",\"spark.sql.streaming.flatMapGroupsWithState.stateFormatVersion\":\"2\",\"spark.sql.streaming.multipleWatermarkPolicy\":\"min\",\"spark.sql.streaming.aggregation.stateFormatVersion\":\"2\",\"spark.sql.shuffle.partitions\":\"200\"}}\n",
+    "{\"sourceVersion\":1,\"reservoirId\":\"027b3701-5c07-46d4-9d96-e5539f81e8bf\",\"reservoirVersion\":33,\"index\":17,\"isStartingVersion\":true}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "4c02d514-5320-4e1d-abfc-1ef6497ab69b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "streamingQuery.stop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "8c85a0a7-513e-42f8-82b4-a279b6f0d9b7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'message': 'Stopped', 'isDataAvailable': False, 'isTriggerActive': False}"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "streamingQuery.status\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0f8787b-836c-4101-a126-279de702238d",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## View the Checkpoint Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "611cc35e-a070-4f2a-b084-6d068fbb7d9d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "v1\n",
+      "{\"batchWatermarkMs\":1570578599000,\"batchTimestampMs\":1687853100013,\"conf\":{\"spark.sql.streaming.stateStore.providerClass\":\"org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider\",\"spark.sql.streaming.join.stateFormatVersion\":\"2\",\"spark.sql.streaming.stateStore.compression.codec\":\"lz4\",\"spark.sql.streaming.stateStore.rocksdb.formatVersion\":\"5\",\"spark.sql.streaming.statefulOperator.useStrictDistribution\":\"true\",\"spark.sql.streaming.flatMapGroupsWithState.stateFormatVersion\":\"2\",\"spark.sql.streaming.multipleWatermarkPolicy\":\"min\",\"spark.sql.streaming.aggregation.stateFormatVersion\":\"2\",\"spark.sql.shuffle.partitions\":\"200\"}}\n",
+      "{\"sourceVersion\":1,\"reservoirId\":\"027b3701-5c07-46d4-9d96-e5539f81e8bf\",\"reservoirVersion\":33,\"index\":17,\"isStartingVersion\":true}"
+     ]
+    }
+   ],
+   "source": [
+    "%%sh\n",
+    "cat ../../applications/dl_streaming_aggs/v0.0.1/_checkpoints/offsets/17"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03e9d7ff-acb3-4450-b718-ca434ec7aca8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Applications have State in the form of Checkpoints. \n",
+    "> Delta maintains its state in the terms of completed atomic transactions.\n",
+    "\n",
+    "The application checkpoints track where the application has last successfully read from the Delta Lake table (source), and the application also keeps track of the delta version based on the resulting transformation and insert into the (sink). In our case we read from the `default.ecomm_by_day` and did some windowed aggregations for events per session, and then recorded the results in a new table named `default.ecomm_aggs_table`.\n",
+    "\n",
+    "Let's peak at the checkpoint data. Open up `"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce70c11e-dcbb-4c49-a1cc-cb051d90ce59",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## The Fruits of our Quick Labor\n",
+    "The shopping aggregations is our own 'sessionization' based on things that would work for the hitchhikers guide to Delta Lake streaming. Have we learned a lot from the data? Maybe. Have we learned a lot more about how Delta Lake works? Surely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "e3f2b354-6637-4a54-b30f-d1672f39fa59",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------------------------------------+---------+----------+----------+--------------+\n",
+      "|window                                    |user_id  |product_id|event_date|session_events|\n",
+      "+------------------------------------------+---------+----------+----------+--------------+\n",
+      "|{2019-10-01 17:30:00, 2019-10-01 18:00:00}|536922877|3101045   |2019-10-01|2             |\n",
+      "|{2019-10-01 20:00:00, 2019-10-01 20:30:00}|521595164|3601405   |2019-10-01|4             |\n",
+      "|{2019-10-01 19:00:00, 2019-10-01 19:30:00}|542537982|26401412  |2019-10-01|1             |\n",
+      "|{2019-10-01 19:00:00, 2019-10-01 19:30:00}|544624772|26204073  |2019-10-01|1             |\n",
+      "|{2019-10-01 17:30:00, 2019-10-01 18:00:00}|555732683|28715756  |2019-10-01|1             |\n",
+      "|{2019-10-01 22:00:00, 2019-10-01 22:30:00}|554327957|1005008   |2019-10-01|1             |\n",
+      "|{2019-10-01 19:00:00, 2019-10-01 19:30:00}|515086886|1005104   |2019-10-01|1             |\n",
+      "|{2019-10-01 20:00:00, 2019-10-01 20:30:00}|555779608|1005105   |2019-10-01|1             |\n",
+      "|{2019-10-01 18:00:00, 2019-10-01 18:30:00}|542450933|12701845  |2019-10-01|1             |\n",
+      "|{2019-10-01 19:30:00, 2019-10-01 20:00:00}|512650709|1201458   |2019-10-01|1             |\n",
+      "+------------------------------------------+---------+----------+----------+--------------+\n",
+      "only showing top 10 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "(spark.read\n",
+    " .table(\"default.ecomm_aggs_table\")\n",
+    " .where(col(\"event_date\").isin(\"2019-10-01\",\"2019-10-02\"))\n",
+    " .show(10, truncate=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bd05bd4-7963-4c40-8e08-b9df76a296ca",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## Extra Homework: Finding Neat Patterns in the Data\n",
+    "> shopping is fun. We all do it, some of us even enjoy it. Regardless of your style, the one thing we have in common is that not one of us really shops the same. Investigate the 42 million shopping data points from this dataset to understand how people are shopping. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a68175a-e3ca-4181-949f-331b041ed2bf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "(spark.read\n",
+    " .table(dl_managed_table)\n",
+    " .select(\"event_time\", \"event_type\", \"product_id\", \"user_session\", \"user_id\")\n",
+    " .show(100, truncate=False)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5cb4f97-dcfb-4b49-a523-5eaeca53642e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# find a user who has an interesting shopping pattern\n",
+    "# this user comes back frequently, views, comes back, and 10 days from the first\n",
+    "# view finally makes a purchase\n",
+    "\n",
+    "(spark.read\n",
+    " .table(dl_managed_table)\n",
+    " .select(\"event_time\", \"event_type\", \"product_id\", \"user_id\", \"user_session\")\n",
+    " .where(col(\"user_id\").eqNullSafe(516224384))\n",
+    " .show(100, truncate=False)\n",
+    ")"
    ]
   },
   {
@@ -366,7 +579,7 @@
    "outputs": [],
    "source": [
     "spark.conf.set(\"spark.databricks.delta.retentionDurationCheck.enabled\",\"false\")\n",
-    "DeltaTable.forPath(spark, f\"{delta_path}/{dl_table_name}\").vacuum(retentionHours=0)\n",
+    "DeltaTable.forName(spark, ecomm_aggs_table).vacuum(retentionHours=0)\n",
     "spark.conf.set(\"spark.databricks.delta.retentionDurationCheck.enabled\",\"true\")"
    ]
   }

--- a/hitchhikers_guide/notebooks/first-steps/dl-streaming-101.ipynb
+++ b/hitchhikers_guide/notebooks/first-steps/dl-streaming-101.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "a457036d-1d98-46e0-a64e-52faa61300e1",
    "metadata": {
     "tags": []
@@ -38,23 +38,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "b4a3f372-ea71-436e-9182-25d66c7b989f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Table(name='ecomm_by_day', database='default', description=None, tableType='MANAGED', isTemporary=False)]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "spark.catalog.setCurrentDatabase(\"default\")\n",
     "spark.catalog.listTables()"
@@ -85,39 +74,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "5075440a-f931-40ea-886e-4249cd10b806",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- format: string (nullable = true)\n",
-      " |-- id: string (nullable = true)\n",
-      " |-- name: string (nullable = true)\n",
-      " |-- description: string (nullable = true)\n",
-      " |-- location: string (nullable = true)\n",
-      " |-- createdAt: timestamp (nullable = true)\n",
-      " |-- lastModified: timestamp (nullable = true)\n",
-      " |-- partitionColumns: array (nullable = true)\n",
-      " |    |-- element: string (containsNull = true)\n",
-      " |-- numFiles: long (nullable = true)\n",
-      " |-- sizeInBytes: long (nullable = true)\n",
-      " |-- properties: map (nullable = true)\n",
-      " |    |-- key: string\n",
-      " |    |-- value: string (valueContainsNull = true)\n",
-      " |-- minReaderVersion: integer (nullable = true)\n",
-      " |-- minWriterVersion: integer (nullable = true)\n",
-      " |-- tableFeatures: array (nullable = true)\n",
-      " |    |-- element: string (containsNull = true)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Starting Small (Baby Steps)\n",
     "dt_ecomm = DeltaTable.forName(spark, dl_managed_table)\n",
@@ -135,6 +97,28 @@
     "### Table Details. Providing you with all the ... well details\n",
     "Scanning the StructType of the `detail()` dataframe gives you a lot of data. The following use cases can be solved with the metadata:\n",
     "\n",
+    "```\n",
+    "root\n",
+    " |-- format: string (nullable = true)\n",
+    " |-- id: string (nullable = true)\n",
+    " |-- name: string (nullable = true)\n",
+    " |-- description: string (nullable = true)\n",
+    " |-- location: string (nullable = true)\n",
+    " |-- createdAt: timestamp (nullable = true)\n",
+    " |-- lastModified: timestamp (nullable = true)\n",
+    " |-- partitionColumns: array (nullable = true)\n",
+    " |    |-- element: string (containsNull = true)\n",
+    " |-- numFiles: long (nullable = true)\n",
+    " |-- sizeInBytes: long (nullable = true)\n",
+    " |-- properties: map (nullable = true)\n",
+    " |    |-- key: string\n",
+    " |    |-- value: string (valueContainsNull = true)\n",
+    " |-- minReaderVersion: integer (nullable = true)\n",
+    " |-- minWriterVersion: integer (nullable = true)\n",
+    " |-- tableFeatures: array (nullable = true)\n",
+    " |    |-- element: string (containsNull = true)\n",
+    "```\n",
+    "\n",
     "1. **Calculate Table Freshness**: `abs(current_time()-{table.lastModified})`: To answer the universal question of - \"How Fresh Is It?\".\n",
     "2. **How Fast is the Table Growing?**: Size does matter. If we have two tables, tableA is 100gb and has `createdAt` of one year ago, and tableB is 100gb and was created yesterday, then we've got a scalability monster. Using the `freshness` technique, you can calculate the `days` a table has `existed`, and calculate the `avg` bytes per day using `sizeInBytes`.\n",
     "3. **What is the Table Telling Us?**: Using the `properties` map, we can easily view ALL Table Properties, including those used to `automate` Delta Lake like `delta.logRetentionDuration` or those *we bring to the table* - pun truly intended. Like `catalog.team_name`"
@@ -142,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 4,
    "id": "5c3eb912-19c2-4354-8abf-954701bde8eb",
    "metadata": {
     "tags": []
@@ -155,7 +139,7 @@
       "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
       "|now                       |todays_date|createdAt              |lastModified           |age_in_days|stale_days|\n",
       "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
-      "|2023-06-26 05:37:31.179219|2023-06-26 |2023-06-24 00:13:12.254|2023-06-24 00:33:45.298|2          |2         |\n",
+      "|2023-06-26 16:10:11.637598|2023-06-26 |2023-06-24 00:13:12.254|2023-06-24 00:33:45.298|2          |2         |\n",
       "+--------------------------+-----------+-----------------------+-----------------------+-----------+----------+\n",
       "\n",
       "Don't Panic!\n",
@@ -199,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 5,
    "id": "1474d650-5a72-47ea-9214-b327b0a75da8",
    "metadata": {
     "tags": []
@@ -244,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 6,
    "id": "de32047a-73c9-46fc-9858-178cbf1bab06",
    "metadata": {
     "tags": []
@@ -294,7 +278,7 @@
     "Because we have potentially a gigantic amount of data - (Or depending on the adventure you chose a smaller set of 60, yes it should have been 42, but time...) - regardless, it is time to create our first streaming application.\n",
     "\n",
     "## What We'll Need\n",
-    "1. A Place to Store our Application Metadata. Luckily we have our Local File Sytem, so we can just store the application data there for now.\n",
+    "1. A Place to Store our Application Metadata. Luckily we have our Local File Sytem, so we can just store the application data there for now. (See [common application directory](../../applications/README.md) to understand a little more.\n",
     "2. A [Way of Restricting the Volume of Data We Read](https://docs.delta.io/latest/delta-streaming.html#limit-input-rate)\n",
     "3. A [Means of Ignoring Things](https://docs.databricks.com/structured-streaming/delta-lake.html#ignore-updates-and-deletes) we don't currently care about.\n",
     "3. A Way of Limiting the Frequency in which our Application Runs (just like we want to limit the volume of data, when we start learning how to work with Streaming Data, it is better to slowly increase the rate which we will learn how to do.)"
@@ -302,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 7,
    "id": "c78ea8fe-c4ab-48cd-b3e6-65aa4fadf7a3",
    "metadata": {
     "tags": []
@@ -312,6 +296,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "checkpoint_path=../../applications/dl_streaming_aggs/v0.0.1/_checkpoints\n",
       "root\n",
       " |-- event_time: timestamp (nullable = true)\n",
       " |-- event_type: string (nullable = true)\n",
@@ -332,6 +317,13 @@
     "# read up to 4 files, do a simple projection (select colA, colB)\n",
     "# write out to a new Delta Lake table. \n",
     "# Checkpoint the progress so we can `pick up where we left off`\n",
+    "\n",
+    "app_name = \"dl_streaming_aggs\"\n",
+    "app_version = \"v0.0.1\"\n",
+    "checkpoint_dir = \"../../applications\"\n",
+    "checkpoint_path = f\"{checkpoint_dir}/{app_name}/{app_version}/_checkpoints\"\n",
+    "print(f\"checkpoint_path={checkpoint_path}\")\n",
+    "\n",
     "# oh, and only do this Once, so introduce `trigger(once=True)` since we will be `ramping` up to full streaming\n",
     "\n",
     "# create the streaming Delta source object\n",


### PR DESCRIPTION
## Description
This PR adds a 'sessionization' use case to round out the introduction to using Delta Lake Streaming. The nice thing about the end to end source is that while the code isn't super difficult, the problem being solved is a doing fairly interesting sessionization across user's from the open-source ecomm retail dataset. In under 10 minutes you can incrementally read the entire 42 million records, aggregate, and sessionize, and then dump into a new shiny Delta Lake table.

## How was this patch tested?
It works and may I add, works well.

## Does this PR introduce _any_ user-facing changes?
Nope.